### PR TITLE
Make validate route actually useful

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1,9 +1,8 @@
 var express    = require('express');
-var request    = require('request');
 var bodyParser = require('body-parser');
-
-var httpProxy = require('http-proxy');
-var apiProxy = httpProxy.createProxyServer();
+var reqwest = require('reqwest');
+var libxml = require('libxmljs2');
+var fs = require('fs');
 
 module.exports = function(app) {
     app.use( bodyParser.json() );       // to support JSON-encoded bodies
@@ -14,16 +13,35 @@ module.exports = function(app) {
     // file statici e index.html in app/
     app.use('/', express.static('.'));
 
+    var xsd_190_buf = fs.readFileSync('src/static/datasetAppaltiL190.xsd');
+    var xsd_190 = libxml.parseXmlString(xsd_190_buf.toString());
+
     app.post('/validate', function (request, response) {
         if (!request.body.url) {
-	    response.status(400).end();
-	    return;
-	}
-	const url = new URL(request.body.url);
-
-	// TODO:
-	// - get url
-	// - validate all the things
-        response.send({});
+            response.status(400).end();
+            return;
+        }
+        const url = new URL(request.body.url);
+        reqwest({
+            url: url.href,
+        }).then(function(resp) {
+            try {
+                var xml_doc = libxml.parseXmlString(resp);
+                var valid = xml_doc.validate(xsd_190);
+                response.send({
+                    'url': url.href,
+                    'valid': valid,
+                    'errors': xml_doc.validationErrors,
+                });
+            } catch(error) {
+                response.send({
+                    'url': url.href,
+                    'valid': false,
+                    'errors': ['File is invalid XML document: ' + error],
+                });
+            }
+        }).fail(function(err, msg) {
+            response.send({});
+        });
     });
 };

--- a/src/static/datasetAppaltiL190.xsd
+++ b/src/static/datasetAppaltiL190.xsd
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:legge190="legge190_1_0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="legge190_1_0" version="1.0">
+	<xsd:simpleType name="CigType">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="10"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="ImportoType">
+		<xsd:restriction base="xsd:decimal">
+			<xsd:minInclusive value="0"/>
+			<xsd:maxInclusive value="999999999999.99"/>
+			<xsd:totalDigits value="15"/>
+			<xsd:fractionDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="codiceFiscaleType">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[A-Za-z]{6}[0-9]{2}[A-Za-z]{1}[0-9]{2}[A-Za-z]{1}[0-9A-Za-z]{3}[A-Za-z]{1}"/>
+			<xsd:pattern value="[A-Za-z]{6}[0-9LMNPQRSTUV]{2}[A-Za-z]{1}[0-9LMNPQRSTUV]{2}[A-Za-z]{1}[0-9LMNPQRSTUV]{3}[A-Za-z]{1}"/>
+			<xsd:pattern value="[0-9]{11,11}"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="sceltaContraenteType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="01-PROCEDURA APERTA"/>
+			<xsd:enumeration value="02-PROCEDURA RISTRETTA"/>
+			<xsd:enumeration value="03-PROCEDURA NEGOZIATA PREVIA PUBBLICAZIONE DEL BANDO"/>
+			<xsd:enumeration value="04-PROCEDURA NEGOZIATA SENZA PREVIA PUBBLICAZIONE DEL BANDO"/>
+			<xsd:enumeration value="05-DIALOGO COMPETITIVO"/>
+			<xsd:enumeration value="06-PROCEDURA NEGOZIATA SENZA PREVIA INDIZIONE DI  GARA ART. 221 D.LGS. 163/2006"/>
+			<xsd:enumeration value="07-SISTEMA DINAMICO DI ACQUISIZIONE"/>
+			<xsd:enumeration value="08-AFFIDAMENTO IN ECONOMIA - COTTIMO FIDUCIARIO"/>
+			<xsd:enumeration value="14-PROCEDURA SELETTIVA EX ART 238 C.7, D.LGS. 163/2006"/>
+			<xsd:enumeration value="17-AFFIDAMENTO DIRETTO EX ART. 5 DELLA LEGGE N.381/91"/>
+			<xsd:enumeration value="21-PROCEDURA RISTRETTA DERIVANTE DA AVVISI CON CUI SI INDICE LA GARA"/>
+			<xsd:enumeration value="22-PROCEDURA NEGOZIATA DERIVANTE DA AVVISI CON CUI SI INDICE LA GARA"/>
+			<xsd:enumeration value="23-AFFIDAMENTO IN ECONOMIA - AFFIDAMENTO DIRETTO"/>
+			<xsd:enumeration value="24-AFFIDAMENTO DIRETTO A SOCIETA' IN HOUSE"/>
+			<xsd:enumeration value="25-AFFIDAMENTO DIRETTO A SOCIETA' RAGGRUPPATE/CONSORZIATE O CONTROLLATE NELLE CONCESSIONI DI LL.PP"/>
+			<xsd:enumeration value="26-AFFIDAMENTO DIRETTO IN ADESIONE AD ACCORDO QUADRO/CONVENZIONE"/>
+			<xsd:enumeration value="27-CONFRONTO COMPETITIVO IN ADESIONE AD ACCORDO QUADRO/CONVENZIONE"/>
+			<xsd:enumeration value="28-PROCEDURA AI SENSI DEI REGOLAMENTI DEGLI ORGANI COSTITUZIONALI"/>
+			<xsd:enumeration value="29-PROCEDURA RISTRETTA SEMPLIFICATA"/>
+			<xsd:enumeration value="30-PROCEDURA DERIVANTE DA LEGGE REGIONALE"/>
+			<xsd:enumeration value="31-AFFIDAMENTO DIRETTO PER VARIANTE SUPERIORE AL 20% DELL'IMPORTO CONTRATTUALE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="denominazioneType">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="250"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="oggettoType">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="250"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="ruoloType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="01-MANDANTE"/>
+			<xsd:enumeration value="02-MANDATARIA"/>
+			<xsd:enumeration value="03-ASSOCIATA"/>
+			<xsd:enumeration value="04-CAPOGRUPPO"/>
+			<xsd:enumeration value="05-CONSORZIATA"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="pubblicazione">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="metadata">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="titolo" type="xsd:string"/>
+							<xsd:element name="abstract" type="xsd:string"/>
+							<xsd:element name="dataPubbicazioneDataset" type="xsd:date" nillable="false"/>
+							<xsd:element name="entePubblicatore" type="xsd:string" nillable="false"/>
+							<xsd:element name="dataUltimoAggiornamentoDataset" type="xsd:date"/>
+							<xsd:element name="annoRiferimento" type="xsd:int" nillable="false"/>
+							<!--riferimento al file stesso-->
+							<xsd:element name="urlFile" type="xsd:anyURI" nillable="false"/>
+							<xsd:element name="licenza"/>
+							<!--licenza opendata-->
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="data">
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="lotto" minOccurs="0" maxOccurs="unbounded">
+								<xsd:complexType>
+									<xsd:sequence>
+										<xsd:element name="cig" type="legge190:CigType" nillable="false"/>
+										<xsd:element name="strutturaProponente" nillable="false">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="codiceFiscaleProp" type="legge190:codiceFiscaleType" nillable="false"/>
+													<xsd:element name="denominazione" type="legge190:denominazioneType" nillable="false"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="oggetto" type="legge190:oggettoType" nillable="false"/>
+										<xsd:element name="sceltaContraente" type="legge190:sceltaContraenteType" nillable="false"/>
+										<xsd:element name="partecipanti">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="raggruppamento" minOccurs="0" maxOccurs="unbounded">
+														<xsd:complexType>
+															<xsd:sequence>
+																<xsd:element name="membro" type="legge190:aggregatoType" minOccurs="2" maxOccurs="unbounded"/>
+															</xsd:sequence>
+														</xsd:complexType>
+													</xsd:element>
+													<xsd:element name="partecipante" type="legge190:singoloType" minOccurs="0" maxOccurs="unbounded"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="aggiudicatari">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="aggiudicatarioRaggruppamento" minOccurs="0" maxOccurs="unbounded">
+														<xsd:complexType>
+															<xsd:sequence>
+																<xsd:element name="membro" type="legge190:aggregatoType" minOccurs="2" maxOccurs="unbounded"/>
+															</xsd:sequence>
+														</xsd:complexType>
+													</xsd:element>
+													<xsd:element name="aggiudicatario" type="legge190:singoloType" minOccurs="0" maxOccurs="unbounded"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="importoAggiudicazione" type="legge190:ImportoType"/>
+										<xsd:element name="tempiCompletamento">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="dataInizio" type="xsd:date" minOccurs="0"/>
+													<xsd:element name="dataUltimazione" type="xsd:date" minOccurs="0"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="importoSommeLiquidate" type="legge190:ImportoType"/>
+									</xsd:sequence>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<!--strutture tipo interne-->
+	<xsd:complexType name="aggregatoType">
+		<xsd:sequence>
+			<xsd:annotation>
+				<xsd:documentation>E' obbligatorio almeno uno tra codice Fiscale e identificativo estero</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice>
+				<xsd:element name="codiceFiscale" type="legge190:codiceFiscaleType" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="identificativoFiscaleEstero" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			</xsd:choice>
+			<xsd:element name="ragioneSociale" type="legge190:denominazioneType" minOccurs="1"/>
+			<xsd:element name="ruolo" type="legge190:ruoloType" minOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="singoloType">
+		<xsd:sequence>
+			<xsd:annotation>
+				<xsd:documentation>E' obbligatorio almeno uno tra codice Fiscale e identificativo estero</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice>
+				<xsd:element name="codiceFiscale" type="legge190:codiceFiscaleType" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="identificativoFiscaleEstero" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			</xsd:choice>
+			<xsd:element name="ragioneSociale" type="legge190:denominazioneType" minOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
The api will gladly take an xml url via POST and try to validate
it against local xsd. E.g.:

```
$ http POST http://localhost:8080/validate \
    url=http://www.servizipubblicaamministrazione.it/siti/ssl301/l190/DataSetL1902017.xml

HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 116
Content-Type: application/json; charset=utf-8
Date: Mon, 03 Jun 2019 18:32:35 GMT
ETag: W/"74-GuPbCxMkhra2S45U3FwH4qm7CNk"
Vary: Accept-Encoding
X-Powered-By: Express

{
    "errors": [],
    "url": "http://www.servizipubblicaamministrazione.it/siti/ssl301/l190/DataSetL1902017.xml",
    "valid": true
}
```